### PR TITLE
Update pinenacl dependency to version 0.6.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   crypto: ^3.0.3
   json_annotation: ^4.8.0
-  pinenacl: ^0.5.1
+  pinenacl: ^0.6.0
   solana_borsh: ^0.0.1
     # path: ../solana_borsh
   solana_buffer: ^0.0.1


### PR DESCRIPTION
This pull request updates the pinenacl dependency from version 0.5.1 to 0.6.0. The update resolves an issue related to the UnmodifiableUint8ListView class, which was causing build errors in Dart SDK versions where this class is not available.